### PR TITLE
Fix content-type in GET requests

### DIFF
--- a/lib/sign_host/api_client.rb
+++ b/lib/sign_host/api_client.rb
@@ -31,7 +31,7 @@ module SignHost
     end
 
     def get_transaction(transaction_id)
-      RestClient.get(transaction_url(transaction_id), auth_headers.merge(content_type: 'application/json', accept: 'application/json')){ |response, request, result, &block |
+      RestClient.get(transaction_url(transaction_id), auth_headers.merge(accept: 'application/json')){ |response, request, result, &block |
         case response.code
         when 200
           JSON.parse(response.body)


### PR DESCRIPTION
The content-type header should not be provided during a GET request as the request does not have a payload.
This behaviour breaks communication with the SignHost API, although there's currently a workaround in place. But the plan is to remove this workaround in the future, as sending the content-type header is not conform spec.